### PR TITLE
Include null as a possible type passed to fromNullable

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -6,7 +6,7 @@ class Maybe<T> extends SumType<{ Nothing: []; Just: [T] }> implements Monad<T> {
     return Just(t);
   }
 
-  static fromNullable<T>(t?: T): Maybe<T> {
+  static fromNullable<T>(t: T | undefined | null): Maybe<T> {
     return t ? Just(t) : Nothing();
   }
 


### PR DESCRIPTION
Optional params are equivalent to `T | undefined` so we need to also
include null