### PR TITLE
Add effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,27 @@ Err("oops").caseOf({
 Ok("Loki").map(name => name.toUpperCase()); // => Just("LOKI")
 Err("oops").map(name => name.toUpperCase()); // => Err("oops")
 
-// flatMap unnests a layer when the mapper returns a Maybe
+// flatMap unnests a layer when the mapper returns a Result
 Ok("Loki").flatMap(name => Ok(name.toUpperCase())); // => Ok("LOKI")
 Err("oops").flatMap(name => Ok(name.toUpperCase())); // => Err("oops")
 
 // Result and Maybe are not isomorphic as "oops" is lost when converting Err to Nothing
-Ok("Loki").toMaybe(); // => Just("Loki")
-Err("oops").toMaybe(); // => Nothing()
+Ok("Loki").toMaybe(); // => Ok("Loki")
+Err("oops").toMaybe(); // => Err("oops")
+```
+
+## Effect
+
+```ts
+import { Effect } from 'seidr';
+
+const fooEff = Effect(() => "foo") // Effect("foo")
+
+fooEff.unsafePerform() // => 'foo'
+
+// Map doesn't run on Err
+fooEff.map(val => val.toUpperCase()); // => Effect("FOO")
+
+// flatMap unnests a layer when the mapper returns an Effect
+fooEffect.flatMap(val => Effect(() => val + 'bar'); // => Effect("foobar")
 ```

--- a/__tests__/effect.test.ts
+++ b/__tests__/effect.test.ts
@@ -1,0 +1,45 @@
+import * as Effect from '../src/effect';
+
+describe('Effect', () => {
+  describe('#unsafePerform', () => {
+    it('runs the thunk', () => {
+      expect(Effect.Effect(() => 'thunk-value').unsafePerform()).toBe('thunk-value');
+    });
+  });
+
+  describe('#map', () => {
+    it('maps over the value', () => {
+      expect(Effect.Effect(() => 'foo').map(x => x + 'bar').unsafePerform()).toBe('foobar');
+    });
+  });
+
+  describe('#flatMap', () => {
+    it('combines multiple effects', () => {
+      expect(
+        Effect.Effect(() => 'foo')
+          .flatMap(f => 
+            Effect.Effect(() => 'bar').map(b => `${f}${b}`)
+          ).unsafePerform()
+      ).toBe('foobar');
+    });
+  });
+
+  describe('unsafePerform', () => {
+    it('executes the effect', () => {
+      const effect = Effect.Effect(() => 'thunk-value');
+      expect(Effect.unsafePerform(effect)).toBe('thunk-value');
+    });
+  });
+
+  describe('none', () => {
+    it('returns an effect that does nothing', () => {
+      expect(Effect.none().unsafePerform()).toBe(undefined);
+    });
+  });
+
+  describe('of', () => {
+    it('wraps a value in an effect', () => {
+      expect(Effect.of('value').unsafePerform()).toBe('value');
+    });
+  });
+});

--- a/__tests__/maybe.test.ts
+++ b/__tests__/maybe.test.ts
@@ -11,7 +11,7 @@ describe('Maybe', () => {
     describe('flatMap', () => {
       describe('with a mapper that returns Nothing', () => {
         test('it disregards the mapper and returns a Nothing', () => {
-          expect(Nothing<number>().flatMap((x: number) => Nothing())).toEqual(
+          expect(Nothing<number>().flatMap((_: number) => Nothing())).toEqual(
             Nothing()
           );
         });
@@ -19,7 +19,7 @@ describe('Maybe', () => {
 
       describe('with a mapper that returns Just', () => {
         test('it disregards the mapper and returns a Nothing', () => {
-          expect(Nothing<number>().flatMap((x: number) => Just(2))).toEqual(
+          expect(Nothing<number>().flatMap((_: number) => Just(2))).toEqual(
             Nothing()
           );
         });
@@ -43,13 +43,13 @@ describe('Maybe', () => {
     describe('flatMap', () => {
       describe('with a mapper that returns Nothing', () => {
         test('it returns a Nothing', () => {
-          expect(Just(3).flatMap((x: number) => Nothing())).toEqual(Nothing());
+          expect(Just(3).flatMap((_: number) => Nothing())).toEqual(Nothing());
         });
       });
 
       describe('with a mapper that returns Just', () => {
         test('it returns the Just from the mapper', () => {
-          expect(Just(3).flatMap((x: number) => Just(16))).toEqual(Just(16));
+          expect(Just(3).flatMap((_: number) => Just(16))).toEqual(Just(16));
         });
       });
     });

--- a/__tests__/result.test.ts
+++ b/__tests__/result.test.ts
@@ -1,8 +1,6 @@
 import { Result, Ok, Err } from '../src/result';
 import { Nothing, Just } from '../src/maybe';
 
-console.log(Result.fromNullable);
-
 describe('Result', () => {
   describe('Err', () => {
     describe('map', () => {

--- a/src/effect.ts
+++ b/src/effect.ts
@@ -1,0 +1,48 @@
+import SumType from 'sums-up';
+import { Mapper } from './functor';
+import { Monad } from './monad';
+
+export type Thunk<T> = (...args: unknown[]) => T;
+
+class Eff<T> extends SumType<{ Effect: [Thunk<T>] }> implements Monad<T> {
+  public unsafePerform(): T {
+    return this.caseOf({
+      Effect: thunk => thunk(),
+    });
+  }
+
+  public map<U>(mapper: Mapper<T, U>): Effect<U> {
+    return this.caseOf({
+      Effect: thunk => Effect(() => mapper(thunk()))
+    });
+  }
+
+  public flatMap<U>(mapper: (t: T) => Effect<U>): Effect<U> {
+    return this.caseOf({
+      Effect: thunk => mapper(thunk())
+    });
+  }
+
+}
+
+export type Effect<T> = Eff<T>;
+
+export function Effect<T>(thunk: Thunk<T>): Eff<T> {
+  return new Eff('Effect', thunk);
+}
+
+export function unsafePerform<T>(eff: Effect<T>): T {
+  return eff.unsafePerform();
+}
+
+const NONE = Effect(() => {});
+
+export function none(): Effect<void> {
+  return NONE;
+}
+
+export function of<T>(value: T): Effect<T> {
+  return Effect(() => value);
+}
+
+export default Effect;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,13 @@
-import { Maybe, Nothing, Just } from './maybe';
-import { Result, Err, Ok } from './result';
+// -- Foundational
+
 import Functor from './functor';
 import Applicative from './applicative';
 import Monad from './monad';
 
-export { Maybe, Nothing, Just, Result, Err, Ok, Functor, Applicative, Monad };
+// -- Types
+
+import { Effect } from './effect';
+import { Maybe, Nothing, Just } from './maybe';
+import { Result, Err, Ok } from './result';
+
+export { Maybe, Nothing, Just, Result, Err, Ok, Functor, Applicative, Monad, Effect };


### PR DESCRIPTION
Add the Effect type. A similar type to Elm's Cmd and Haskell's IO.
Wraps import functions to allow them to be run later and supports
compositionality through Functor and Monad.