### PR TITLE
Add RemoteData sum type

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,50 @@ fooEff.map(val => val.toUpperCase()); // => Effect("FOO")
 // flatMap unnests a layer when the mapper returns an Effect
 fooEffect.flatMap(val => Effect(() => val + 'bar'); // => Effect("foobar")
 ```
+
+## RemoteData
+
+A sums-up implementation of the original pattern described by Kris Jenkins:
+http://blog.jenkster.com/2016/06/how-elm-slays-a-ui-antipattern.html
+
+This is a helpful sum type for modelling data being fetched from the network.
+
+```typescript
+type RemoteData<E, A> = NotAsked | Loading | Failure<E> | Success<A>
+```
+
+```typescript
+import { RemoteData, NotAsked, Loading, Failure, Success } from 'seidr';
+
+NotAsked().caseOf({
+  NotAsked: () => "not asked",
+  _: () => "everything else",
+}); // => "not asked"
+
+Loading().caseOf({
+  Loading: () => "loading",
+  _: () => "everything else",
+}); // => "loading"
+
+Failure("oops").caseOf({
+  Failure: err => err
+  _: () => "everything else",
+}); // => "oops"
+
+Success("Yay").caseOf({
+  Success: data => data
+  _: () => "everything else",
+}); // => "yay"
+
+// Map only runs on Success
+Succecss("Loki").map(name => name.toUpperCase()); // => Just("LOKI")
+Failure("oops").map(name => name.toUpperCase()); // => Failure("oops")
+Loading().map(name => name.toUpperCase()); // => Loading()
+NotAsked().map(name => name.toUpperCase()); // => NotAsked()
+
+// flatMap unnests a layer when the mapper returns a Result when run on Success
+Succecss("Loki").map(name => Success(name.toUpperCase())); // => Just("LOKI")
+Failure("oops").map(name => Success(name.toUpperCase())); // => Failure("oops")
+Loading().map(name => Success(name.toUpperCase())); // => Loading()
+NotAsked().map(name => Success(name.toUpperCase())); // => NotAsked()
+```

--- a/__tests__/remote_data.test.ts
+++ b/__tests__/remote_data.test.ts
@@ -4,7 +4,7 @@ describe("RemoteData", () => {
   describe("NotAsked", () => {
     describe("map", () => {
       test("it disregards the mapper and returns a NotAsked", () => {
-        expect(NotAsked<number>().map(x => x + 2)).toEqual(NotAsked());
+        expect(NotAsked<Error, number>().map(x => x + 2)).toEqual(NotAsked());
       });
     });
 
@@ -26,7 +26,7 @@ describe("RemoteData", () => {
   describe("Loading", () => {
     describe("map", () => {
       test("it disregards the mapper and returns a Loading", () => {
-        expect(Loading<number>().map(x => x + 2)).toEqual(Loading());
+        expect(Loading<Error, number>().map(x => x + 2)).toEqual(Loading());
       });
     });
 
@@ -48,9 +48,9 @@ describe("RemoteData", () => {
   describe("Failure", () => {
     describe("map", () => {
       test("it disregards the mapper and returns a Failure", () => {
-        expect(Failure<number>(new Error("oops")).map(x => x + 2)).toEqual(
-          Failure(new Error("oops"))
-        );
+        expect(
+          Failure<Error, number>(new Error("oops")).map(x => x + 2)
+        ).toEqual(Failure(new Error("oops")));
       });
     });
 
@@ -84,7 +84,7 @@ describe("RemoteData", () => {
       describe("with a mapper that returns Failure", () => {
         test("it returns a Failure", () => {
           expect(
-            Success<number>(3).flatMap(_ => Failure(new Error("oops")))
+            Success<Error, number>(3).flatMap(_ => Failure(new Error("oops")))
           ).toEqual(Failure(new Error("oops")));
         });
       });

--- a/__tests__/remote_data.test.ts
+++ b/__tests__/remote_data.test.ts
@@ -1,0 +1,99 @@
+import { NotAsked, Loading, Failure, Success } from "../src/remote_data";
+
+describe("RemoteData", () => {
+  describe("NotAsked", () => {
+    describe("map", () => {
+      test("it disregards the mapper and returns a NotAsked", () => {
+        expect(NotAsked<number>().map(x => x + 2)).toEqual(NotAsked());
+      });
+    });
+
+    describe("flatMap", () => {
+      describe("with a mapper that returns NotAsked", () => {
+        test("it disregards the mapper and returns a NotAsked", () => {
+          expect(NotAsked().flatMap(_ => NotAsked())).toEqual(NotAsked());
+        });
+      });
+
+      describe("with a mapper that returns Success", () => {
+        test("it disregards the mapper and returns a NotAsked", () => {
+          expect(NotAsked().flatMap(_ => Success(2))).toEqual(NotAsked());
+        });
+      });
+    });
+  });
+
+  describe("Loading", () => {
+    describe("map", () => {
+      test("it disregards the mapper and returns a Loading", () => {
+        expect(Loading<number>().map(x => x + 2)).toEqual(Loading());
+      });
+    });
+
+    describe("flatMap", () => {
+      describe("with a mapper that returns Loading", () => {
+        test("it disregards the mapper and returns a Loading", () => {
+          expect(Loading().flatMap(_ => Loading())).toEqual(Loading());
+        });
+      });
+
+      describe("with a mapper that returns Success", () => {
+        test("it disregards the mapper and returns a Loading", () => {
+          expect(Loading().flatMap(_ => Success(2))).toEqual(Loading());
+        });
+      });
+    });
+  });
+
+  describe("Failure", () => {
+    describe("map", () => {
+      test("it disregards the mapper and returns a Failure", () => {
+        expect(Failure<number>(new Error("oops")).map(x => x + 2)).toEqual(
+          Failure(new Error("oops"))
+        );
+      });
+    });
+
+    describe("flatMap", () => {
+      describe("with a mapper that returns Failure", () => {
+        test("it disregards the mapper and returns a Failure", () => {
+          expect(
+            Failure(new Error("oops")).flatMap(_ => Failure(new Error(":(")))
+          ).toEqual(Failure(new Error("oops")));
+        });
+      });
+
+      describe("with a mapper that returns Success", () => {
+        test("it disregards the mapper and returns a Failure", () => {
+          expect(Failure(new Error("oops")).flatMap(_ => Success(2))).toEqual(
+            Failure(new Error("oops"))
+          );
+        });
+      });
+    });
+  });
+
+  describe("Success", () => {
+    describe("map", () => {
+      test("it runs the mapper and re-wraps in a Success", () => {
+        expect(Success(3).map(x => x + 2)).toEqual(Success(5));
+      });
+    });
+
+    describe("flatMap", () => {
+      describe("with a mapper that returns Failure", () => {
+        test("it returns a Failure", () => {
+          expect(
+            Success<number>(3).flatMap(_ => Failure(new Error("oops")))
+          ).toEqual(Failure(new Error("oops")));
+        });
+      });
+
+      describe("with a mapper that returns Success", () => {
+        test("it returns the Success from the mapper", () => {
+          expect(Success(3).flatMap(_ => Success(16))).toEqual(Success(16));
+        });
+      });
+    });
+  });
+});

--- a/src/remote_data.ts
+++ b/src/remote_data.ts
@@ -1,0 +1,52 @@
+import SumType from "sums-up";
+import Monad from "./monad";
+
+type RemoteDataVariants<T> = {
+  NotAsked: [];
+  Loading: [];
+  Failure: [Error];
+  Success: [T];
+};
+
+class RemoteData<T> extends SumType<RemoteDataVariants<T>> implements Monad<T> {
+  public static of<T>(t: T): RemoteData<T> {
+    return Success(t);
+  }
+
+  public map<U>(f: (t: T) => U): RemoteData<U> {
+    return this.caseOf({
+      NotAsked: () => NotAsked(),
+      Loading: () => Loading(),
+      Failure: e => Failure(e),
+      Success: (data: T) => Success(f(data))
+    });
+  }
+
+  public flatMap<U>(f: (t: T) => RemoteData<U>): RemoteData<U> {
+    return this.caseOf({
+      NotAsked: () => NotAsked(),
+      Loading: () => Loading(),
+      Failure: e => Failure(e),
+      Success: (data: T) => f(data)
+    });
+  }
+}
+
+function NotAsked<T>(): RemoteData<T> {
+  return new RemoteData<T>("NotAsked");
+}
+
+function Loading<T>(): RemoteData<T> {
+  return new RemoteData<T>("Loading");
+}
+
+function Failure<T>(e: Error): RemoteData<T> {
+  return new RemoteData<T>("Failure", e);
+}
+
+function Success<T>(data: T): RemoteData<T> {
+  return new RemoteData<T>("Success", data);
+}
+
+export default RemoteData;
+export { RemoteData, NotAsked, Loading, Failure, Success };

--- a/src/remote_data.ts
+++ b/src/remote_data.ts
@@ -1,19 +1,20 @@
 import SumType from "sums-up";
 import Monad from "./monad";
 
-type RemoteDataVariants<T> = {
+type RemoteDataVariants<E, T> = {
   NotAsked: [];
   Loading: [];
-  Failure: [Error];
+  Failure: [E];
   Success: [T];
 };
 
-class RemoteData<T> extends SumType<RemoteDataVariants<T>> implements Monad<T> {
-  public static of<T>(t: T): RemoteData<T> {
+class RemoteData<E, T> extends SumType<RemoteDataVariants<E, T>>
+  implements Monad<T> {
+  public static of<E, T>(t: T): RemoteData<E, T> {
     return Success(t);
   }
 
-  public map<U>(f: (t: T) => U): RemoteData<U> {
+  public map<U>(f: (t: T) => U): RemoteData<E, U> {
     return this.caseOf({
       NotAsked: () => NotAsked(),
       Loading: () => Loading(),
@@ -22,7 +23,7 @@ class RemoteData<T> extends SumType<RemoteDataVariants<T>> implements Monad<T> {
     });
   }
 
-  public flatMap<U>(f: (t: T) => RemoteData<U>): RemoteData<U> {
+  public flatMap<U>(f: (t: T) => RemoteData<E, U>): RemoteData<E, U> {
     return this.caseOf({
       NotAsked: () => NotAsked(),
       Loading: () => Loading(),
@@ -32,20 +33,20 @@ class RemoteData<T> extends SumType<RemoteDataVariants<T>> implements Monad<T> {
   }
 }
 
-function NotAsked<T>(): RemoteData<T> {
-  return new RemoteData<T>("NotAsked");
+function NotAsked<E, T>(): RemoteData<E, T> {
+  return new RemoteData<E, T>("NotAsked");
 }
 
-function Loading<T>(): RemoteData<T> {
-  return new RemoteData<T>("Loading");
+function Loading<E, T>(): RemoteData<E, T> {
+  return new RemoteData<E, T>("Loading");
 }
 
-function Failure<T>(e: Error): RemoteData<T> {
-  return new RemoteData<T>("Failure", e);
+function Failure<E, T>(e: E): RemoteData<E, T> {
+  return new RemoteData<E, T>("Failure", e);
 }
 
-function Success<T>(data: T): RemoteData<T> {
-  return new RemoteData<T>("Success", data);
+function Success<E, T>(data: T): RemoteData<E, T> {
+  return new RemoteData<E, T>("Success", data);
 }
 
 export default RemoteData;


### PR DESCRIPTION
Add a new sum type in the shape of (pseudo typescript):

```typescript
type RemoteData<E, A> = NotAsked | Loading | Failure<E> | Success<A>
```

This follows the same naming principles from the original Elm
implementation: http://blog.jenkster.com/2016/06/how-elm-slays-a-ui-antipattern.html