### PR TITLE
More explicit nullable check

### DIFF
--- a/__tests__/maybe.test.ts
+++ b/__tests__/maybe.test.ts
@@ -71,8 +71,11 @@ describe('Maybe', () => {
 
     describe('when passed a valid value', () => {
       test('it returns a Just', () => {
+        expect(Maybe.fromNullable("")).toEqual(Just(""));
         expect(Maybe.fromNullable("Test")).toEqual(Just("Test"));
         expect(Maybe.fromNullable(123)).toEqual(Just(123));
+        expect(Maybe.fromNullable(0)).toEqual(Just(0));
+        expect(Maybe.fromNullable(false)).toEqual(Just(false));
       });
     });
   });

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -7,7 +7,7 @@ class Maybe<T> extends SumType<{ Nothing: []; Just: [T] }> implements Monad<T> {
   }
 
   public static fromNullable<T>(t: T | undefined | null): Maybe<T> {
-    return t ? Just(t) : Nothing();
+    return t === null || t === undefined ? Nothing() : Just(t);
   }
 
   public map<U>(f: (t: T) => U): Maybe<U> {


### PR DESCRIPTION
`Maybe.fromNullable` was having some trouble with falsey values, I figured an explicit `null`/`undefined` check might make sense.