### PR TITLE
Assume `never` for unspecified types in `Result` and `Maybe`

### DIFF
--- a/__tests__/maybe.test.ts
+++ b/__tests__/maybe.test.ts
@@ -52,6 +52,17 @@ describe('Maybe', () => {
           expect(Just(3).flatMap((_: number) => Just(16))).toEqual(Just(16));
         });
       });
+
+      describe('with a mapper that might return Just or Nothing', () => {
+        test('it infers the correct new type value for `T`', () => {
+          // This is more a test of type inference than runtime behavior
+          expect(
+            Just(3)
+              .flatMap(_ => (Math.random() > 0.5 ? Just('hello') : Nothing()))
+              .map(value => value.length)
+          ).toBeTruthy();
+        });
+      });
     });
 
     describe('getOrElse', () => {

--- a/__tests__/result.test.ts
+++ b/__tests__/result.test.ts
@@ -25,7 +25,7 @@ describe('Result', () => {
       describe('with a mapper that returns Ok', () => {
         test('it disregards the mapper and returns a Err', () => {
           expect(
-            Err<Error, number>(new Error('oops')).flatMap(_ => Ok(2))
+            Err(new Error('oops')).flatMap(_ => Ok(2))
           ).toEqual(Err(new Error('oops')));
         });
       });
@@ -41,7 +41,7 @@ describe('Result', () => {
   describe('Ok', () => {
     describe('map', () => {
       test('it runs the mapper and re-wraps in a Ok', () => {
-        expect(Ok<Error, number>(3).map((x: number) => x + 2)).toEqual(Ok(5));
+        expect(Ok(3).map((x: number) => x + 2)).toEqual(Ok(5));
       });
     });
 
@@ -49,7 +49,7 @@ describe('Result', () => {
       describe('with a mapper that returns Err', () => {
         test('it returns a Err', () => {
           expect(
-            Ok<Error, number>(3).flatMap(_ => Err(new Error('oops')))
+            Ok(3).flatMap(_ => Err(new Error('oops')))
           ).toEqual(Err(new Error('oops')));
         });
       });
@@ -57,6 +57,20 @@ describe('Result', () => {
       describe('with a mapper that returns Ok', () => {
         test('it returns the Ok from the mapper', () => {
           expect(Ok(3).flatMap(_ => Ok(16))).toEqual(Ok(16));
+        });
+      });
+
+      describe('with a mapper that might return Ok or Err', () => {
+        test('it infers the correct new type value for `R`', () => {
+          // This is more a test of type inference than runtime behavior
+          expect(
+            Ok(3)
+              .flatMap(_ => (Math.random() > 0.5 ? Ok('hello') : Err(123)))
+              .bimap(
+                shouldBeANumber => shouldBeANumber.toFixed(),
+                shouldBeAString => shouldBeAString.length,
+              )
+          ).toBeTruthy();
         });
       });
     });
@@ -83,7 +97,7 @@ describe('Result', () => {
 
     describe('when passed a valid value', () => {
       test('it returns an Ok', () => {
-        expect(Result.fromNullable(err, "Test")).toEqual(Ok("Test"));
+        expect(Result.fromNullable(err, 'Test')).toEqual(Ok('Test'));
         expect(Result.fromNullable(err, 123)).toEqual(Ok(123));
       });
     });

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -24,7 +24,7 @@ class Maybe<T> extends SumType<{ Nothing: []; Just: [T] }> implements Monad<T> {
     });
   }
 
-  public getOrElse(elseCase: T): T {
+  public getOrElse<U>(elseCase: T | U): T | U {
     return this.caseOf({
       Nothing: () => elseCase,
       Just: (data: T) => data,
@@ -32,7 +32,7 @@ class Maybe<T> extends SumType<{ Nothing: []; Just: [T] }> implements Monad<T> {
   }
 }
 
-function Nothing<T>(): Maybe<T> {
+function Nothing<T = never>(): Maybe<T> {
   return new Maybe<T>('Nothing');
 }
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -9,8 +9,8 @@ class Result<L, R> extends SumType<{ Err: [L]; Ok: [R] }> implements Monad<R> {
 
   public map<U>(f: (t: R) => U): Result<L, U> {
     return this.caseOf({
-      Err: (err: L) => Err<L, U>(err),
-      Ok: (data: R) => Ok<L, U>(f(data)),
+      Err: (err: L) => Err(err),
+      Ok: (data: R) => Ok(f(data)),
     });
   }
 
@@ -19,14 +19,14 @@ class Result<L, R> extends SumType<{ Err: [L]; Ok: [R] }> implements Monad<R> {
    */
   public bimap<C, D>(leftF: (l: L) => C, rightF: (r: R) => D): Result<C, D> {
     return this.caseOf({
-      Err: (err: L) => Err<C, D>(leftF(err)),
-      Ok: (data: R) => Ok<C, D>(rightF(data)),
+      Err: (err: L) => Err(leftF(err)),
+      Ok: (data: R) => Ok(rightF(data)),
     });
   }
 
-  public flatMap<U>(f: (t: R) => Result<L, U>): Result<L, U> {
+  public flatMap<U, V>(f: (t: R) => Result<L | U, V>): Result<L | U, V> {
     return this.caseOf({
-      Err: (err: L) => Err<L, U>(err),
+      Err: (err: L) => Err(err),
       Ok: (data: R) => f(data),
     });
   }
@@ -42,15 +42,15 @@ class Result<L, R> extends SumType<{ Err: [L]; Ok: [R] }> implements Monad<R> {
 /**
  * Constructor for the Err variant (left side) of Result
  */
-function Err<L, R>(error: L): Result<L, R> {
-  return new Result<L, R>('Err', error);
+function Err<L = never, R = never>(error: L): Result<L, R> {
+  return new Result('Err', error);
 }
 
 /**
  * Constructor for the Ok variant (right side) of Result
  */
-function Ok<L, R>(data: R): Result<L, R> {
-  return new Result<L, R>('Ok', data);
+function Ok<L = never, R = never>(data: R): Result<L, R> {
+  return new Result('Ok', data);
 }
 
 export default Result;


### PR DESCRIPTION
When using `Maybe` and `Result`'s `flatMap`, the fact that `Nothing` and `Ok` and `Err` infer `unknown` for the type parameter they know nothing about causes the loss of legitimate type information because of unnecessary widening.

For instance:

```ts
Ok(true).flatMap(value => value ? Ok(123) : Err('💥'));
// should have type `Result<string, number>`, but instead
// has type `Result<unknown, unknown>`.
```

By assuming `never`, we make it so that e.g. `Ok('👍')` is assignable to `Result<T, string>` for any value of `T`, and therefore the resulting either/or types can be merged together appropriately.

For this to work, we have to allow `Maybe#getOrElse` and `Result#flatMap` to _widen_ their value and error types (respectively), since the baseline is now `never` and it's not possible to produce a value of that type.

There's no loss in overall soundness, since the (potentially-)widened type is reflected in the output, and there's an improvement to the overall ergonomics, as this drastically reduces the number of places you need to explicitly specify type parameters due to incomplete inference.
