### PR TITLE
Proposal: `AsyncResult`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,8 @@ An `AsyncResult<L, R>` is a hybrid of a `Result<L, R>` and a `Promise<R>`,
 with the type safety and convenience methods of the former, but the ability
 to capture a not-necessarily-evaluated-yet value of the latter.
 
-An `AsyncResult<L, R>` can be constructed from a `Promise<Result<L, R>>`, or
-from a `Promise<R>` with an appropriate function to convert the promise's
-`unknown` error value to an `L`.
+An `AsyncResult<L, R>` can be constructed from a `Promise<R>` with an
+appropriate function to convert the promise's `unknown` error value to an `L`.
 
 There are also `AsyncOk` and `AsyncErr` functions available as shorthand,
 though in practice these are less frequently useful.
@@ -78,13 +77,9 @@ import { AsyncResult, AsyncOk, AsyncErr } from 'seidr';
 ////////////////////////////////////
 // Constructing an AsyncResult
 
-declare function asyncMakeAResult(): Promise<Result<string, number>>;
-declare function asyncMakeAValue(): Promise<{ name: string }>;
+const myPromise: Promise<{ name: string }> = /* ... */;
 
-new AsyncResult(asyncMakeAResult());
-// => AsyncResult<string, number>;
-
-AsyncResult.fromPromise(err => new Error(String(err)), asyncMakeAValue());
+AsyncResult.fromPromise(err => new Error(String(err)), myPromise);
 // => AsyncResult<Error, { name: string }>
 
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ import { Just, Nothing } from 'seidr';
 
 Just("Loki").caseOf({
   Nothing: () => "N/A",
-  Just: name => `Hello ${name}`, 	
+  Just: name => `Hello ${name}`,
 }); // => "Hello Loki"
 
 Nothing().caseOf({
   Nothing: () => "N/A",
-  Just: name => `Hello ${name}`, 	
+  Just: name => `Hello ${name}`,
 }); // => "N/A"
 
 // Map doesn't run on Nothing
@@ -38,12 +38,12 @@ import { Ok, Err } from 'seidr';
 
 Ok("Loki").caseOf({
   Err: err => err,
-  Ok: name => `Hello ${name}`, 	
+  Ok: name => `Hello ${name}`,
 }); // => "Hello Loki"
 
 Err("oops").caseOf({
   Err: err => err
-  Just: (name) => `Hello ${name}`, 	
+  Just: (name) => `Hello ${name}`,
 }); // => "oops"
 
 // Map doesn't run on Err
@@ -57,6 +57,66 @@ Err("oops").flatMap(name => Ok(name.toUpperCase())); // => Err("oops")
 // Result and Maybe are not isomorphic as "oops" is lost when converting Err to Nothing
 Ok("Loki").toMaybe(); // => Just("Loki")
 Err("oops").toMaybe(); // => Nothing()
+```
+
+## AsyncResult
+
+An `AsyncResult<L, R>` is a hybrid of a `Result<L, R>` and a `Promise<R>`,
+with the type safety and convenience methods of the former, but the ability
+to capture a not-necessarily-evaluated-yet value of the latter.
+
+An `AsyncResult<L, R>` can be constructed from a `Promise<Result<L, R>>`, or
+from a `Promise<R>` with an appropriate function to convert the promise's
+`unknown` error value to an `L`.
+
+There are also `AsyncOk` and `AsyncErr` functions available as shorthand,
+though in practice these are less frequently useful.
+
+````ts
+import { AsyncResult, AsyncOk, AsyncErr } from 'seidr';
+
+////////////////////////////////////
+// Constructing an AsyncResult
+
+declare function asyncMakeAResult(): Promise<Result<string, number>>;
+declare function asyncMakeAValue(): Promise<{ name: string }>;
+
+new AsyncResult(asyncMakeAResult());
+// => AsyncResult<string, number>;
+
+AsyncResult.fromPromise(err => new Error(String(err)), asyncMakeAValue());
+// => AsyncResult<Error, { name: string }>
+
+
+////////////////////////////////////
+// Using an AsyncResult
+
+// `caseOf` always returns a promise
+AsyncOk("Loki").caseOf({
+  Err: err => err,
+  Ok: name => `Hello ${name}`,
+}); // => Promise { <resolved>: "Hello Loki" }
+
+AsyncErr("oops").caseOf({
+  Err: err => err,
+  Ok: (name) => `Hello ${name}`,
+}); // => Promise { <resolved>: "oops" }
+
+// `map` doesn't run on Err
+AsyncOk("Loki").map(name => name.toUpperCase());  // => AsyncOk("LOKI")
+AsyncErr("oops").map(name => name.toUpperCase()); // => AsyncErr("oops")
+
+// `flatMap` unnests a layer when the mapper returns a Result, AsyncResult or Promise<Result>
+AsyncOk("Loki").flatMap(name => Ok(name.toUpperCase()));       // => AsyncOk("LOKI")
+AsyncOk("Loki").flatMap(name => AsyncOk(name.toUpperCase()));  // => AsyncOk("LOKI")
+AsyncOk("Loki").flatMap(async name => Ok(name.toUpperCase())); // => AsyncOk("LOKI")
+AsyncErr("oops").flatMap(name => Ok(name.toUpperCase()));      // => AsyncErr("oops")
+
+// `toPromise` returns promise that resolves on Ok or rejects on Err
+// A `Promise<R>` and an `AsyncResult<L, R>` are isomorphic at runtime,
+// as the error value isn't lost; only the type information is.
+AsyncOk("Loki").toPromise();  // Promise { <resolved>: "Loki" }
+AsyncErr("oops").toPromise(); // Promise { <rejected>: "oops" }
 ```
 
 ## Effect

--- a/__tests__/async_result.test.ts
+++ b/__tests__/async_result.test.ts
@@ -1,11 +1,11 @@
 import { Ok, Err } from '../src/result';
-import AsyncResult from '../src/async_result';
+import { AsyncResult, AsyncOk, AsyncErr } from '../src/async_result';
 
 describe('AsyncResult', () => {
   describe('PromiseLike<Result>', () => {
     test('it acts as a promise for an equivalent synchronous result', async () => {
-      expect(await new AsyncResult(Ok('neat'))).toEqual(Ok('neat'));
-      expect(await new AsyncResult(Err('boom'))).toEqual(Err('boom'));
+      expect(await AsyncOk('neat')).toEqual(Ok('neat'));
+      expect(await AsyncErr('boom')).toEqual(Err('boom'));
     });
   });
 
@@ -23,14 +23,14 @@ describe('AsyncResult', () => {
 
   describe('toPromise', () => {
     test('returns a resolved promise for an Ok value', async () => {
-      expect(await new AsyncResult(Ok('good')).toPromise()).toBe('good');
+      expect(await AsyncOk('good').toPromise()).toBe('good');
     });
 
     test('returns a rejected promise for an Err value', async () => {
       expect.assertions(1);
 
       try {
-        await new AsyncResult(Err('boom')).toPromise();
+        await AsyncErr('boom').toPromise();
       } catch (error) {
         expect(error).toBe('boom');
       }
@@ -39,7 +39,7 @@ describe('AsyncResult', () => {
 
   describe('caseOf', () => {
     test('returns a promise for the result of the matching arm', async () => {
-      let result = new AsyncResult(Ok('neat')).caseOf({
+      let result = AsyncOk('neat').caseOf({
         Ok: value => value.length,
         Err: () => 0
       });
@@ -48,7 +48,7 @@ describe('AsyncResult', () => {
     });
 
     test('allows arms to themselves be async', async () => {
-      let result = new AsyncResult(Err('boom')).caseOf({
+      let result = AsyncErr('boom').caseOf({
         Ok: () => false,
         Err: async () => true
       });
@@ -59,19 +59,19 @@ describe('AsyncResult', () => {
 
   describe('map', () => {
     test('it runs an Ok value through the mapper and returns a new AsyncResult', async () => {
-      let result = new AsyncResult(Ok('hello')).map(async str => str.length);
+      let result = AsyncOk('hello').map(async str => str.length);
       expect(await result).toEqual(Ok(5));
     });
 
     test('it skips the mapper for an Err value', async () => {
-      let result = new AsyncResult(Err('oh no')).map(() => true);
+      let result = AsyncErr('oh no').map(() => true);
       expect(await result).toEqual(Err('oh no'));
     });
   });
 
   describe('bimap', () => {
     test('it runs an Ok value through the Ok mapper and returns a new AsyncResult', async () => {
-      let result = new AsyncResult(Ok('hello')).bimap(
+      let result = AsyncOk('hello').bimap(
         () => false,
         async str => str.length
       );
@@ -80,7 +80,7 @@ describe('AsyncResult', () => {
     });
 
     test('it runs an Err value through the Err mapper and returns a new AsyncResult', async () => {
-      let result = new AsyncResult(Err([1, 2, 3])).bimap(
+      let result = AsyncErr([1, 2, 3]).bimap(
         async err => err.join(''),
         () => false
       );
@@ -90,37 +90,37 @@ describe('AsyncResult', () => {
 
   describe('flatMap', () => {
     test('it skips the mapper for an Err value', async () => {
-      let result = new AsyncResult(Err('hi')).flatMap(() => Ok(123));
+      let result = AsyncErr('hi').flatMap(() => Ok(123));
       expect(await result).toEqual(Err('hi'));
     });
 
     test('it returns Ok for a mapper that returns an Ok', async () => {
-      let result = new AsyncResult(Ok('hi')).flatMap(str => Ok(str.length));
+      let result = AsyncOk('hi').flatMap(str => Ok(str.length));
       expect(await result).toEqual(Ok(2));
     });
 
     test('it returns Err for a mapper that returns an Err', async () => {
-      let result = new AsyncResult(Ok('hi')).flatMap(str => Err(str.length));
+      let result = AsyncOk('hi').flatMap(str => Err(str.length));
       expect(await result).toEqual(Err(2));
     });
 
     test('it returns Ok for a mapper that returns an Ok promise', async () => {
-      let result = new AsyncResult(Ok('hi')).flatMap(async str => Ok(str.length));
+      let result = AsyncOk('hi').flatMap(async str => Ok(str.length));
       expect(await result).toEqual(Ok(2));
     });
 
     test('it returns Err for a mapper that returns an Err promise', async () => {
-      let result = new AsyncResult(Ok('hi')).flatMap(async str => Err(str.length));
+      let result = AsyncOk('hi').flatMap(async str => Err(str.length));
       expect(await result).toEqual(Err(2));
     });
 
     test('it returns Ok for a mapper that returns an Ok AsyncResult', async () => {
-      let result = new AsyncResult(Ok('hi')).flatMap(str => new AsyncResult(Ok(str.length)));
+      let result = AsyncOk('hi').flatMap(str => AsyncOk(str.length));
       expect(await result).toEqual(Ok(2));
     });
 
     test('it returns Err for a mapper that returns an Err promise', async () => {
-      let result = new AsyncResult(Ok('hi')).flatMap(str => new AsyncResult(Err(str.length)));
+      let result = AsyncOk('hi').flatMap(str => AsyncErr(str.length));
       expect(await result).toEqual(Err(2));
     });
   });

--- a/__tests__/async_result.test.ts
+++ b/__tests__/async_result.test.ts
@@ -1,0 +1,127 @@
+import { Ok, Err } from '../src/result';
+import AsyncResult from '../src/async_result';
+
+describe('AsyncResult', () => {
+  describe('PromiseLike<Result>', () => {
+    test('it acts as a promise for an equivalent synchronous result', async () => {
+      expect(await new AsyncResult(Ok('neat'))).toEqual(Ok('neat'));
+      expect(await new AsyncResult(Err('boom'))).toEqual(Err('boom'));
+    });
+  });
+
+  describe('fromPromise', () => {
+    test('takes on the Ok value of a resolved promise', async () => {
+      let result = AsyncResult.fromPromise(() => true, Promise.resolve('good'));
+      expect(await result).toEqual(Ok('good'));
+    });
+
+    test('takes on the Err value of a rejected promise after getting type information from it', async () => {
+      let result = AsyncResult.fromPromise(rejection => String(rejection), Promise.reject(123));
+      expect(await result).toEqual(Err('123'));
+    });
+  });
+
+  describe('toPromise', () => {
+    test('returns a resolved promise for an Ok value', async () => {
+      expect(await new AsyncResult(Ok('good')).toPromise()).toBe('good');
+    });
+
+    test('returns a rejected promise for an Err value', async () => {
+      expect.assertions(1);
+
+      try {
+        await new AsyncResult(Err('boom')).toPromise();
+      } catch (error) {
+        expect(error).toBe('boom');
+      }
+    });
+  });
+
+  describe('caseOf', () => {
+    test('returns a promise for the result of the matching arm', async () => {
+      let result = new AsyncResult(Ok('neat')).caseOf({
+        Ok: value => value.length,
+        Err: () => 0
+      });
+
+      expect(await result).toBe('neat'.length);
+    });
+
+    test('allows arms to themselves be async', async () => {
+      let result = new AsyncResult(Err('boom')).caseOf({
+        Ok: () => false,
+        Err: async () => true
+      });
+
+      expect(await result).toBe(true);
+    });
+  });
+
+  describe('map', () => {
+    test('it runs an Ok value through the mapper and returns a new AsyncResult', async () => {
+      let result = new AsyncResult(Ok('hello')).map(async str => str.length);
+      expect(await result).toEqual(Ok(5));
+    });
+
+    test('it skips the mapper for an Err value', async () => {
+      let result = new AsyncResult(Err('oh no')).map(() => true);
+      expect(await result).toEqual(Err('oh no'));
+    });
+  });
+
+  describe('bimap', () => {
+    test('it runs an Ok value through the Ok mapper and returns a new AsyncResult', async () => {
+      let result = new AsyncResult(Ok('hello')).bimap(
+        () => false,
+        async str => str.length
+      );
+
+      expect(await result).toEqual(Ok(5));
+    });
+
+    test('it runs an Err value through the Err mapper and returns a new AsyncResult', async () => {
+      let result = new AsyncResult(Err([1, 2, 3])).bimap(
+        async err => err.join(''),
+        () => false
+      );
+      expect(await result).toEqual(Err('123'));
+    });
+  });
+
+  describe('flatMap', () => {
+    test('it skips the mapper for an Err value', async () => {
+      let result = new AsyncResult(Err('hi')).flatMap(() => Ok(123));
+      expect(await result).toEqual(Err('hi'));
+    });
+
+    test('it returns Ok for a mapper that returns an Ok', async () => {
+      let result = new AsyncResult(Ok('hi')).flatMap(str => Ok(str.length));
+      expect(await result).toEqual(Ok(2));
+    });
+
+    test('it returns Err for a mapper that returns an Err', async () => {
+      let result = new AsyncResult(Ok('hi')).flatMap(str => Err(str.length));
+      expect(await result).toEqual(Err(2));
+    });
+
+    test('it returns Ok for a mapper that returns an Ok promise', async () => {
+      let result = new AsyncResult(Ok('hi')).flatMap(async str => Ok(str.length));
+      expect(await result).toEqual(Ok(2));
+    });
+
+    test('it returns Err for a mapper that returns an Err promise', async () => {
+      let result = new AsyncResult(Ok('hi')).flatMap(async str => Err(str.length));
+      expect(await result).toEqual(Err(2));
+    });
+
+    test('it returns Ok for a mapper that returns an Ok AsyncResult', async () => {
+      let result = new AsyncResult(Ok('hi')).flatMap(str => new AsyncResult(Ok(str.length)));
+      expect(await result).toEqual(Ok(2));
+    });
+
+    test('it returns Err for a mapper that returns an Err promise', async () => {
+      let result = new AsyncResult(Ok('hi')).flatMap(str => new AsyncResult(Err(str.length)));
+      expect(await result).toEqual(Err(2));
+    });
+  });
+});

--- a/src/async_result.ts
+++ b/src/async_result.ts
@@ -1,0 +1,121 @@
+import Result, { Err, Ok } from './result';
+import Monad from './monad';
+
+type MaybePromise<T> = T | PromiseLike<T>;
+
+/**
+ * A hybrid of a `Result` and a `Promise`, `AsyncResult` includes
+ * the common convenience methods of working with a `Result` such
+ * as `map`, `bimap` and `flatMap`, while representing possibly-
+ * asynchronous state like a `Promise`.
+ *
+ * Aside from the convenience methods, `AsyncResult` also encodes
+ * type information about its error variant, unlike a native
+ * `Promise`, which may reject with `any` value.
+ */
+class AsyncResult<L, R> implements PromiseLike<Result<L, R>>, Monad<R> {
+  private promise: Promise<Result<L, R>>;
+
+  constructor(result: Result<L, R> | PromiseLike<Result<L, R>>) {
+    this.promise = Promise.resolve(result);
+  }
+
+  // Implement `PromiseLike<Result<L, R>>`
+  public then<TResult1 = Result<L, R>, TResult2 = never>(
+    onfulfilled?: ((value: Result<L, R>) => TResult1 | PromiseLike<TResult1>) | null | undefined,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null | undefined
+  ): Promise<TResult1 | TResult2> {
+    return this.promise.then(onfulfilled, onrejected);
+  }
+
+  // This isn't strictly compatible with `SumType`'s `caseOf`,
+  // since it returns `Promise<T>` rather than just `T`, but
+  // it's the conceptual equivalent.
+  public caseOf<T>(conditions: {
+    Err: (err: L) => MaybePromise<T>;
+    Ok: (value: R) => MaybePromise<T>;
+  }): Promise<T> {
+    return this.promise.then(result => result.caseOf(conditions));
+  }
+
+  // Implement `Functor<R>`
+  public map<U>(f: (t: R) => MaybePromise<U>): AsyncResult<L, U> {
+    return this.bimap(l => l, f);
+  }
+
+  public bimap<C, D>(
+    leftF: (l: L) => MaybePromise<C>,
+    rightF: (r: R) => MaybePromise<D>
+  ): AsyncResult<C, D> {
+    return new AsyncResult(
+      this.caseOf({
+        Err: async err => Err<C, D>(await leftF(err)),
+        Ok: async value => Ok<C, D>(await rightF(value))
+      })
+    );
+  }
+
+  // Implement `Monad<R>`.
+  // (This requires multiple signatures to convince TS that we're
+  // successfully implementing monad, even though the second signature
+  // actually encompasses the first, since an AsyncResult is already
+  // a PromiseLike<Result>)
+  public flatMap<U, V>(f: (t: R) => AsyncResult<L | U, V>): AsyncResult<L | U, V>;
+  public flatMap<U, V>(f: (t: R) => MaybePromise<Result<L | U, V>>): AsyncResult<L | U, V>;
+  public flatMap<U, V>(f: (t: R) => MaybePromise<Result<L | U, V>>): AsyncResult<L | U, V> {
+    return new AsyncResult(
+      this.caseOf({
+        Err: error => Err(error),
+        Ok: async value => f(value)
+      })
+    );
+  }
+
+  /**
+   * The conceptual equivalent of `Result.fromNullable`. The key
+   * difference is that promises _do_ carry error information, it's
+   * just not reflected in their type. For that reason, where
+   * `fromNullable` accepts an error value, `fromPromise` accepts a
+   * function that's responsible for taking the `unknown` rejection
+   * value from the promise and returning something typed.
+   */
+  public static fromPromise<L = never, R = never>(
+    error: (rejection: unknown) => L,
+    promise: PromiseLike<R>
+  ): AsyncResult<L, R> {
+    return new AsyncResult(
+      promise.then(
+        value => Ok(value),
+        rejection => Err(error(rejection))
+      )
+    );
+  }
+
+  /**
+   * The inverse of `fromPromise`. This converts an `Ok` value
+   * to a resolved promise, and an `Err` value to a rejected one.
+   *
+   * Note that this erases any type information about the error
+   * case, but is exactly isomorphic at runtime since the actual
+   * error value is not lost.
+   */
+  public toPromise(): Promise<R> {
+    return this.caseOf({
+      Ok: value => value,
+      Err: error => {
+        throw error;
+      }
+    });
+  }
+}
+
+function AsyncOk<L = never, R = never>(value: R): AsyncResult<L, R> {
+  return new AsyncResult(Ok(value));
+}
+
+function AsyncErr<L = never, R = never>(err: L): AsyncResult<L, R> {
+  return new AsyncResult(Err(err));
+}
+
+export default AsyncResult;
+export { AsyncResult, AsyncOk, AsyncErr };

--- a/src/async_result.ts
+++ b/src/async_result.ts
@@ -21,16 +21,10 @@ class AsyncResult<L, R> implements PromiseLike<Result<L, R>>, Monad<R> {
   }
 
   // Implement `PromiseLike<Result<L, R>>`
-  public then<TResult1 = Result<L, R>, TResult2 = never>(
-    onfulfilled?:
-      | ((value: Result<L, R>) => TResult1 | PromiseLike<TResult1>)
-      | null
-      | undefined,
-    onrejected?:
-      | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
-      | null
-      | undefined
-  ): Promise<TResult1 | TResult2> {
+  public then<T = Result<L, R>, U = never>(
+    onfulfilled?: ((value: Result<L, R>) => T | PromiseLike<T>) | null,
+    onrejected?: ((reason: unknown) => U | PromiseLike<U>) | null
+  ): Promise<T | U> {
     return this.promise.then(onfulfilled, onrejected);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { Effect } from "./effect";
 import { RemoteData, NotAsked, Loading, Failure, Success } from "./remote_data";
 import { Maybe, Nothing, Just } from "./maybe";
 import { Result, Err, Ok } from "./result";
+import { AsyncResult, AsyncErr, AsyncOk } from "./async_result";
 
 export {
   Maybe,
@@ -27,4 +28,7 @@ export {
   Loading,
   Failure,
   Success,
+  AsyncResult,
+  AsyncErr,
+  AsyncOk
 };


### PR DESCRIPTION
This PR proposes the addition of an `AsyncResult<L, R>` type as a type-safe alternative to `Promise<R>`, in the same way `Result<L, R>` is a synchronous alternative to `R | <throwing an error>`.

It can act as a drop-in replacement for any `PromiseLike<Result<L, R>>`, but exposes `map`, `flatMap` and friends for easily manipulating the ultimate value in the familiar functional style exposed by the rest of `seidr`.