### PR TITLE
Add helpers for "left side mapping"

### DIFF
--- a/__tests__/maybe.test.ts
+++ b/__tests__/maybe.test.ts
@@ -1,24 +1,24 @@
-import { Maybe, Just, Nothing } from '../src/maybe';
+import { Maybe, Just, Nothing } from "../src/maybe";
 
-describe('Maybe', () => {
-  describe('Nothing', () => {
-    describe('map', () => {
-      test('it disregards the mapper and returns a Nothing', () => {
+describe("Maybe", () => {
+  describe("Nothing", () => {
+    describe("map", () => {
+      test("it disregards the mapper and returns a Nothing", () => {
         expect(Nothing<number>().map((x: number) => x + 2)).toEqual(Nothing());
       });
     });
 
-    describe('flatMap', () => {
-      describe('with a mapper that returns Nothing', () => {
-        test('it disregards the mapper and returns a Nothing', () => {
+    describe("flatMap", () => {
+      describe("with a mapper that returns Nothing", () => {
+        test("it disregards the mapper and returns a Nothing", () => {
           expect(Nothing<number>().flatMap((_: number) => Nothing())).toEqual(
             Nothing()
           );
         });
       });
 
-      describe('with a mapper that returns Just', () => {
-        test('it disregards the mapper and returns a Nothing', () => {
+      describe("with a mapper that returns Just", () => {
+        test("it disregards the mapper and returns a Nothing", () => {
           expect(Nothing<number>().flatMap((_: number) => Just(2))).toEqual(
             Nothing()
           );
@@ -26,62 +26,74 @@ describe('Maybe', () => {
       });
     });
 
-    describe('getOrElse', () => {
-      test('it returns the fallback value', () => {
+    describe("getOrElse", () => {
+      test("it returns the fallback value", () => {
         expect(Nothing().getOrElse(0)).toEqual(0);
+      });
+    });
+
+    describe("orElse", () => {
+      test("it calls the function returning the value", () => {
+        expect(Nothing<number>().orElse(() => Just(3))).toEqual(Just(3));
       });
     });
   });
 
-  describe('Just', () => {
-    describe('map', () => {
-      test('it runs the mapper and re-wraps in a Just', () => {
+  describe("Just", () => {
+    describe("map", () => {
+      test("it runs the mapper and re-wraps in a Just", () => {
         expect(Just(3).map((x: number) => x + 2)).toEqual(Just(5));
       });
     });
 
-    describe('flatMap', () => {
-      describe('with a mapper that returns Nothing', () => {
-        test('it returns a Nothing', () => {
+    describe("flatMap", () => {
+      describe("with a mapper that returns Nothing", () => {
+        test("it returns a Nothing", () => {
           expect(Just(3).flatMap((_: number) => Nothing())).toEqual(Nothing());
         });
       });
 
-      describe('with a mapper that returns Just', () => {
-        test('it returns the Just from the mapper', () => {
+      describe("with a mapper that returns Just", () => {
+        test("it returns the Just from the mapper", () => {
           expect(Just(3).flatMap((_: number) => Just(16))).toEqual(Just(16));
         });
       });
 
-      describe('with a mapper that might return Just or Nothing', () => {
-        test('it infers the correct new type value for `T`', () => {
+      describe("with a mapper that might return Just or Nothing", () => {
+        test("it infers the correct new type value for `T`", () => {
           // This is more a test of type inference than runtime behavior
           expect(
             Just(3)
-              .flatMap(_ => (Math.random() > 0.5 ? Just('hello') : Nothing()))
-              .map(value => value.length)
+              .flatMap((_) => (Math.random() > 0.5 ? Just("hello") : Nothing()))
+              .map((value) => value.length)
           ).toBeTruthy();
         });
       });
     });
 
-    describe('getOrElse', () => {
-      test('it returns the value', () => {
+    describe("getOrElse", () => {
+      test("it returns the value", () => {
         expect(Just(3).getOrElse(0)).toEqual(3);
+      });
+    });
+
+    describe("orElse", () => {
+      test("it disregards the function and returns itself", () => {
+        expect(Just(3).orElse(() => Just(564))).toEqual(Just(3));
       });
     });
   });
 
-  describe('fromNullable', () => {
-    describe('when passed a null or undefined value', () => {
-      test('it returns a Nothing', () => {
+  describe("fromNullable", () => {
+    describe("when passed a null or undefined value", () => {
+      test("it returns a Nothing", () => {
         expect(Maybe.fromNullable(undefined)).toEqual(Nothing());
         expect(Maybe.fromNullable(null)).toEqual(Nothing());
       });
     });
 
-    describe('when passed a valid value', () => {
-      test('it returns a Just', () => {
+    describe("when passed a valid value", () => {
+      test("it returns a Just", () => {
         expect(Maybe.fromNullable("")).toEqual(Just(""));
         expect(Maybe.fromNullable("Test")).toEqual(Just("Test"));
         expect(Maybe.fromNullable(123)).toEqual(Just(123));

--- a/__tests__/remote_data.test.ts
+++ b/__tests__/remote_data.test.ts
@@ -4,20 +4,39 @@ describe("RemoteData", () => {
   describe("NotAsked", () => {
     describe("map", () => {
       test("it disregards the mapper and returns a NotAsked", () => {
-        expect(NotAsked<Error, number>().map(x => x + 2)).toEqual(NotAsked());
+        expect(NotAsked<Error, number>().map((x) => x + 2)).toEqual(NotAsked());
+      });
+    });
+
+    describe("mapFailure", () => {
+      test("it disregards the mapper and returns a NotAsked", () => {
+        expect(NotAsked<Error, number>().mapFailure((e) => e.message)).toEqual(
+          NotAsked()
+        );
+      });
+    });
+
+    describe("bimap", () => {
+      test("it disregards the mappers and returns a NotAsked", () => {
+        expect(
+          NotAsked<Error, number>().bimap(
+            (e) => e.message,
+            (x) => x + 2
+          )
+        ).toEqual(NotAsked());
       });
     });
 
     describe("flatMap", () => {
       describe("with a mapper that returns NotAsked", () => {
         test("it disregards the mapper and returns a NotAsked", () => {
-          expect(NotAsked().flatMap(_ => NotAsked())).toEqual(NotAsked());
+          expect(NotAsked().flatMap((_) => NotAsked())).toEqual(NotAsked());
         });
       });
 
       describe("with a mapper that returns Success", () => {
         test("it disregards the mapper and returns a NotAsked", () => {
-          expect(NotAsked().flatMap(_ => Success(2))).toEqual(NotAsked());
+          expect(NotAsked().flatMap((_) => Success(2))).toEqual(NotAsked());
         });
       });
     });
@@ -26,20 +45,39 @@ describe("RemoteData", () => {
   describe("Loading", () => {
     describe("map", () => {
       test("it disregards the mapper and returns a Loading", () => {
-        expect(Loading<Error, number>().map(x => x + 2)).toEqual(Loading());
+        expect(Loading<Error, number>().map((x) => x + 2)).toEqual(Loading());
+      });
+    });
+
+    describe("mapFailure", () => {
+      test("it disregards the mapper and returns a Loading", () => {
+        expect(Loading<Error, number>().mapFailure((e) => e.message)).toEqual(
+          Loading()
+        );
+      });
+    });
+
+    describe("bimap", () => {
+      test("it disregards the mappers and returns a Loading", () => {
+        expect(
+          Loading<Error, number>().bimap(
+            (e) => e.message,
+            (x) => x + 2
+          )
+        ).toEqual(Loading());
       });
     });
 
     describe("flatMap", () => {
       describe("with a mapper that returns Loading", () => {
         test("it disregards the mapper and returns a Loading", () => {
-          expect(Loading().flatMap(_ => Loading())).toEqual(Loading());
+          expect(Loading().flatMap((_) => Loading())).toEqual(Loading());
         });
       });
 
       describe("with a mapper that returns Success", () => {
         test("it disregards the mapper and returns a Loading", () => {
-          expect(Loading().flatMap(_ => Success(2))).toEqual(Loading());
+          expect(Loading().flatMap((_) => Success(2))).toEqual(Loading());
         });
       });
     });
@@ -49,8 +87,27 @@ describe("RemoteData", () => {
     describe("map", () => {
       test("it disregards the mapper and returns a Failure", () => {
         expect(
-          Failure<Error, number>(new Error("oops")).map(x => x + 2)
+          Failure<Error, number>(new Error("oops")).map((x) => x + 2)
         ).toEqual(Failure(new Error("oops")));
+      });
+    });
+
+    describe("mapFailure", () => {
+      test("it maps Failure", () => {
+        expect(
+          Failure<Error, number>(new Error("hi")).mapFailure((e) => e.message)
+        ).toEqual(Failure<string, number>("hi"));
+      });
+    });
+
+    describe("bimap", () => {
+      test("it maps Failure", () => {
+        expect(
+          Failure<Error, number>(new Error("hi")).bimap(
+            (e) => e.message,
+            (x) => x + 2
+          )
+        ).toEqual(Failure<string, number>("hi"));
       });
     });
 
@@ -58,14 +115,14 @@ describe("RemoteData", () => {
       describe("with a mapper that returns Failure", () => {
         test("it disregards the mapper and returns a Failure", () => {
           expect(
-            Failure(new Error("oops")).flatMap(_ => Failure(new Error(":(")))
+            Failure(new Error("oops")).flatMap((_) => Failure(new Error(":(")))
           ).toEqual(Failure(new Error("oops")));
         });
       });
 
       describe("with a mapper that returns Success", () => {
         test("it disregards the mapper and returns a Failure", () => {
-          expect(Failure(new Error("oops")).flatMap(_ => Success(2))).toEqual(
+          expect(Failure(new Error("oops")).flatMap((_) => Success(2))).toEqual(
             Failure(new Error("oops"))
           );
         });
@@ -76,7 +133,26 @@ describe("RemoteData", () => {
   describe("Success", () => {
     describe("map", () => {
       test("it runs the mapper and re-wraps in a Success", () => {
-        expect(Success(3).map(x => x + 2)).toEqual(Success(5));
+        expect(Success(3).map((x) => x + 2)).toEqual(Success(5));
+      });
+    });
+
+    describe("mapFailure", () => {
+      test("it disregards the mapper and returns a Loading", () => {
+        expect(Loading<Error, number>().mapFailure((e) => e.message)).toEqual(
+          Loading()
+        );
+      });
+    });
+
+    describe("bimap", () => {
+      test("it maps Success", () => {
+        expect(
+          Success<Error, number>(4).bimap(
+            (e) => e.message,
+            (x) => x + 2
+          )
+        ).toEqual(Success<Error, number>(6));
       });
     });
 
@@ -84,14 +160,14 @@ describe("RemoteData", () => {
       describe("with a mapper that returns Failure", () => {
         test("it returns a Failure", () => {
           expect(
-            Success<Error, number>(3).flatMap(_ => Failure(new Error("oops")))
+            Success<Error, number>(3).flatMap((_) => Failure(new Error("oops")))
           ).toEqual(Failure(new Error("oops")));
         });
       });
 
       describe("with a mapper that returns Success", () => {
         test("it returns the Success from the mapper", () => {
-          expect(Success(3).flatMap(_ => Success(16))).toEqual(Success(16));
+          expect(Success(3).flatMap((_) => Success(16))).toEqual(Success(16));
         });
       });
     });

--- a/__tests__/result.test.ts
+++ b/__tests__/result.test.ts
@@ -1,103 +1,117 @@
-import { Result, Ok, Err } from '../src/result';
-import { Nothing, Just } from '../src/maybe';
+import { Result, Ok, Err } from "../src/result";
+import { Nothing, Just } from "../src/maybe";
 
-describe('Result', () => {
-  describe('Err', () => {
-    describe('map', () => {
-      test('it disregards the mapper and returns a Err', () => {
+describe("Result", () => {
+  describe("Err", () => {
+    describe("map", () => {
+      test("it disregards the mapper and returns a Err", () => {
+        expect(Err<Error, number>(new Error("oops")).map((x) => x + 2)).toEqual(
+          Err(new Error("oops"))
+        );
+      });
+    });
+
+    describe("mapErr", () => {
+      test("it maps Err", () => {
         expect(
-          Err<Error, number>(new Error('oops')).map((x: number) => x + 2)
-        ).toEqual(Err(new Error('oops')));
+          Err<Error, number>(new Error("oops")).mapErr((e) => e.message)
+        ).toEqual(Err("oops"));
       });
     });
 
-    describe('flatMap', () => {
-      describe('with a mapper that returns Err', () => {
-        test('it disregards the mapper and returns a Err', () => {
+    describe("flatMap", () => {
+      describe("with a mapper that returns Err", () => {
+        test("it disregards the mapper and returns a Err", () => {
           expect(
-            Err<Error, number>(new Error('oops')).flatMap(_ =>
-              Err(new Error(':('))
+            Err<Error, number>(new Error("oops")).flatMap((_) =>
+              Err(new Error(":("))
             )
-          ).toEqual(Err(new Error('oops')));
+          ).toEqual(Err(new Error("oops")));
         });
       });
 
-      describe('with a mapper that returns Ok', () => {
-        test('it disregards the mapper and returns a Err', () => {
-          expect(
-            Err(new Error('oops')).flatMap(_ => Ok(2))
-          ).toEqual(Err(new Error('oops')));
+      describe("with a mapper that returns Ok", () => {
+        test("it disregards the mapper and returns a Err", () => {
+          expect(Err(new Error("oops")).flatMap((_) => Ok(2))).toEqual(
+            Err(new Error("oops"))
+          );
         });
       });
     });
 
-    describe('toMaybe', () => {
-      test('it returns a Nothing', () => {
-        expect(Err(new Error('oops')).toMaybe()).toEqual(Nothing());
+    describe("toMaybe", () => {
+      test("it returns a Nothing", () => {
+        expect(Err(new Error("oops")).toMaybe()).toEqual(Nothing());
       });
     });
   });
 
-  describe('Ok', () => {
-    describe('map', () => {
-      test('it runs the mapper and re-wraps in a Ok', () => {
+  describe("Ok", () => {
+    describe("map", () => {
+      test("it runs the mapper and re-wraps in a Ok", () => {
         expect(Ok(3).map((x: number) => x + 2)).toEqual(Ok(5));
       });
     });
 
-    describe('flatMap', () => {
-      describe('with a mapper that returns Err', () => {
-        test('it returns a Err', () => {
-          expect(
-            Ok(3).flatMap(_ => Err(new Error('oops')))
-          ).toEqual(Err(new Error('oops')));
+    describe("mapErr", () => {
+      test("it disregards the mapper and returns Ok", () => {
+        expect(Ok<Error, number>(3).mapErr((e) => e.message)).toEqual(Ok(3));
+      });
+    });
+
+    describe("flatMap", () => {
+      describe("with a mapper that returns Err", () => {
+        test("it returns a Err", () => {
+          expect(Ok(3).flatMap((_) => Err(new Error("oops")))).toEqual(
+            Err(new Error("oops"))
+          );
         });
       });
 
-      describe('with a mapper that returns Ok', () => {
-        test('it returns the Ok from the mapper', () => {
-          expect(Ok(3).flatMap(_ => Ok(16))).toEqual(Ok(16));
+      describe("with a mapper that returns Ok", () => {
+        test("it returns the Ok from the mapper", () => {
+          expect(Ok(3).flatMap((_) => Ok(16))).toEqual(Ok(16));
         });
       });
 
-      describe('with a mapper that might return Ok or Err', () => {
-        test('it infers the correct new type value for `R`', () => {
+      describe("with a mapper that might return Ok or Err", () => {
+        test("it infers the correct new type value for `R`", () => {
           // This is more a test of type inference than runtime behavior
           expect(
             Ok(3)
-              .flatMap(_ => (Math.random() > 0.5 ? Ok('hello') : Err(123)))
+              .flatMap((_) => (Math.random() > 0.5 ? Ok("hello") : Err(123)))
               .bimap(
-                shouldBeANumber => shouldBeANumber.toFixed(),
-                shouldBeAString => shouldBeAString.length,
+                (shouldBeANumber) => shouldBeANumber.toFixed(),
+                (shouldBeAString) => shouldBeAString.length
               )
           ).toBeTruthy();
         });
       });
     });
 
-    describe('toMaybe', () => {
-      test('it returns a Just of the Ok value', () => {
+    describe("toMaybe", () => {
+      test("it returns a Just of the Ok value", () => {
         expect(Ok(3).toMaybe()).toEqual(Just(3));
       });
     });
   });
 
-  describe('fromNullable', () => {
+  describe("fromNullable", () => {
     let err: Error;
     beforeEach(() => {
-      err = new Error('unable to convert');
+      err = new Error("unable to convert");
     });
 
-    describe('when passed a null or undefined value', () => {
-      test('it returns an Err', () => {
+    describe("when passed a null or undefined value", () => {
+      test("it returns an Err", () => {
         expect(Result.fromNullable(err, undefined)).toEqual(Err(err));
         expect(Result.fromNullable(err, null)).toEqual(Err(err));
       });
     });
 
-    describe('when passed a valid value', () => {
-      test('it returns an Ok', () => {
-        expect(Result.fromNullable(err, 'Test')).toEqual(Ok('Test'));
+    describe("when passed a valid value", () => {
+      test("it returns an Ok", () => {
+        expect(Result.fromNullable(err, "Test")).toEqual(Ok("Test"));
         expect(Result.fromNullable(err, 123)).toEqual(Ok(123));
       });
     });

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1,5 +1,5 @@
-import SumType from 'sums-up';
-import Monad from './monad';
+import SumType from "sums-up";
+import Monad from "./monad";
 
 class Maybe<T> extends SumType<{ Nothing: []; Just: [T] }> implements Monad<T> {
   public static of<T>(t: T): Maybe<T> {
@@ -8,6 +8,10 @@ class Maybe<T> extends SumType<{ Nothing: []; Just: [T] }> implements Monad<T> {
 
   public static fromNullable<T>(t: T | undefined | null): Maybe<T> {
     return t === null || t === undefined ? Nothing() : Just(t);
+  }
+
+  public static withDefault<T, U>(elseCase: T | U, m: Maybe<T>): T | U {
+    return m.getOrElse(elseCase);
   }
 
   public map<U>(f: (t: T) => U): Maybe<U> {
@@ -30,14 +34,21 @@ class Maybe<T> extends SumType<{ Nothing: []; Just: [T] }> implements Monad<T> {
       Just: (data: T) => data,
     });
   }
+
+  public orElse(f: () => Maybe<T>): Maybe<T> {
+    return this.caseOf({
+      Nothing: () => f(),
+      Just: (_) => this,
+    });
+  }
 }
 
 function Nothing<T = never>(): Maybe<T> {
-  return new Maybe<T>('Nothing');
+  return new Maybe<T>("Nothing");
 }
 
 function Just<T>(data: T): Maybe<T> {
-  return new Maybe<T>('Just', data);
+  return new Maybe<T>("Just", data);
 }
 
 export default Maybe;

--- a/src/remote_data.ts
+++ b/src/remote_data.ts
@@ -18,8 +18,17 @@ class RemoteData<E, T> extends SumType<RemoteDataVariants<E, T>>
     return this.caseOf({
       NotAsked: () => NotAsked(),
       Loading: () => Loading(),
-      Failure: e => Failure(e),
-      Success: (data: T) => Success(f(data))
+      Failure: (e) => Failure(e),
+      Success: (data) => Success(f(data)),
+    });
+  }
+
+  public mapFailure<D>(f: (e: E) => D): RemoteData<D, T> {
+    return this.caseOf({
+      NotAsked: () => NotAsked(),
+      Loading: () => Loading(),
+      Failure: (e) => Failure(f(e)),
+      Success: (data) => Success(data),
     });
   }
 
@@ -27,8 +36,20 @@ class RemoteData<E, T> extends SumType<RemoteDataVariants<E, T>>
     return this.caseOf({
       NotAsked: () => NotAsked(),
       Loading: () => Loading(),
-      Failure: e => Failure(e),
-      Success: (data: T) => f(data)
+      Failure: (e) => Failure(e),
+      Success: (data: T) => f(data),
+    });
+  }
+
+  public bimap<C, D>(
+    leftF: (l: E) => C,
+    rightF: (r: T) => D
+  ): RemoteData<C, D> {
+    return this.caseOf({
+      NotAsked: () => NotAsked(),
+      Loading: () => Loading(),
+      Failure: (err) => Failure(leftF(err)),
+      Success: (data) => Success(rightF(data)),
     });
   }
 }

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,39 +1,46 @@
-import SumType from 'sums-up';
-import Monad from './monad';
-import { Maybe, Nothing, Just } from './maybe';
+import SumType from "sums-up";
+import Monad from "./monad";
+import { Maybe, Nothing, Just } from "./maybe";
 
 class Result<L, R> extends SumType<{ Err: [L]; Ok: [R] }> implements Monad<R> {
-  public static fromNullable<L, R>(error: L, x: R | undefined | null): Result<L, R> {
+  public static fromNullable<L, R>(
+    error: L,
+    x: R | undefined | null
+  ): Result<L, R> {
     return x ? Ok(x) : Err(error);
   }
 
   public map<U>(f: (t: R) => U): Result<L, U> {
     return this.caseOf({
-      Err: (err: L) => Err(err),
-      Ok: (data: R) => Ok(f(data)),
+      Err: (err) => Err(err),
+      Ok: (data) => Ok(f(data)),
     });
   }
 
-  /**
-   * Map over both variants
-   */
+  public mapErr<K>(f: (e: L) => K): Result<K, R> {
+    return this.caseOf({
+      Err: (err) => Err(f(err)),
+      Ok: (data) => Ok(data),
+    });
+  }
+
   public bimap<C, D>(leftF: (l: L) => C, rightF: (r: R) => D): Result<C, D> {
     return this.caseOf({
-      Err: (err: L) => Err(leftF(err)),
-      Ok: (data: R) => Ok(rightF(data)),
+      Err: (err) => Err(leftF(err)),
+      Ok: (data) => Ok(rightF(data)),
     });
   }
 
   public flatMap<U, V>(f: (t: R) => Result<L | U, V>): Result<L | U, V> {
     return this.caseOf({
-      Err: (err: L) => Err(err),
-      Ok: (data: R) => f(data),
+      Err: (err) => Err(err),
+      Ok: (data) => f(data),
     });
   }
 
   public toMaybe(): Maybe<R> {
     return this.caseOf({
-      Err: (_: L) => Nothing(),
+      Err: (_) => Nothing(),
       Ok: Just,
     });
   }
@@ -43,14 +50,14 @@ class Result<L, R> extends SumType<{ Err: [L]; Ok: [R] }> implements Monad<R> {
  * Constructor for the Err variant (left side) of Result
  */
 function Err<L = never, R = never>(error: L): Result<L, R> {
-  return new Result('Err', error);
+  return new Result("Err", error);
 }
 
 /**
  * Constructor for the Ok variant (right side) of Result
  */
 function Ok<L = never, R = never>(data: R): Result<L, R> {
-  return new Result('Ok', data);
+  return new Result("Ok", data);
 }
 
 export default Result;


### PR DESCRIPTION
* Turn `RemoteData` into a bifunctor with `bimap` for `Failure` and
  `Success`
* Add `mapFailure` to `RemoteData`
* Add `mapErr` to `Result`
* Add `orElse` to `Maybe`
* Add `Maybe.withDefault`, a static alternative to `getOrElse`.