### PR TITLE
add maybe::pair

### DIFF
--- a/__tests__/maybe.test.ts
+++ b/__tests__/maybe.test.ts
@@ -26,6 +26,16 @@ describe("Maybe", () => {
       });
     });
 
+    describe("and", () => {
+      test("it returns Nothing and-ed to a Nothing", () => {
+        expect(Nothing<number>().and(Nothing<number>())).toEqual(Nothing());
+      });
+
+      test("it returns Nothing and-ed to a Just", () => {
+        expect(Nothing<number>().and(Just(1))).toEqual(Nothing());
+      });
+    });
+
     describe("getOrElse", () => {
       test("it returns the fallback value", () => {
         expect(Nothing().getOrElse(0)).toEqual(0);
@@ -43,6 +53,16 @@ describe("Maybe", () => {
     describe("map", () => {
       test("it runs the mapper and re-wraps in a Just", () => {
         expect(Just(3).map((x: number) => x + 2)).toEqual(Just(5));
+      });
+    });
+
+    describe("and", () => {
+      test("it returns Nothing and-ed to a Nothing", () => {
+        expect(Just(1).and(Nothing<number>())).toEqual(Nothing());
+      });
+
+      test("it returns a tuple and-ed to a Just", () => {
+        expect(Just(1).and(Just(2))).toEqual(Just([1,2]));
       });
     });
 

--- a/__tests__/maybe.test.ts
+++ b/__tests__/maybe.test.ts
@@ -26,13 +26,13 @@ describe("Maybe", () => {
       });
     });
 
-    describe("mapWith", () => {
-      test("it returns a Nothing when mapWith Nothing", () => {
-        expect(Nothing<number>().mapWith(Nothing<number>(), () => 1)).toEqual(Nothing());
+    describe("map2", () => {
+      test("it returns a Nothing when map2 Nothing", () => {
+        expect(Nothing<number>().map2(Nothing<number>(), () => 1)).toEqual(Nothing());
       });
 
-      test("it returns a Nothing when mapWith Just", () => {
-        expect(Nothing<number>().mapWith(Just(1), () => 1)).toEqual(Nothing());
+      test("it returns a Nothing when map2 Just", () => {
+        expect(Nothing<number>().map2(Just(1), () => 1)).toEqual(Nothing());
       });
     });
 
@@ -66,13 +66,13 @@ describe("Maybe", () => {
       });
     });
 
-    describe("mapWith", () => {
-      test("it returns a Nothing when mapWith Nothing", () => {
-        expect(Just(1).mapWith(Nothing<number>(), (a, b) => a + b)).toEqual(Nothing());
+    describe("map2", () => {
+      test("it returns a Nothing when map2 Nothing", () => {
+        expect(Just(1).map2(Nothing<number>(), (a, b) => a + b)).toEqual(Nothing());
       });
 
-      test("it returns a Nothing when mapWith Just", () => {
-        expect(Just(1).mapWith(Just(1), (a, b) => a + b)).toEqual(Just(2));
+      test("it returns a Nothing when map2 Just", () => {
+        expect(Just(1).map2(Just(1), (a, b) => a + b)).toEqual(Just(2));
       });
     });
 

--- a/__tests__/maybe.test.ts
+++ b/__tests__/maybe.test.ts
@@ -26,13 +26,23 @@ describe("Maybe", () => {
       });
     });
 
-    describe("and", () => {
-      test("it returns Nothing and-ed to a Nothing", () => {
-        expect(Nothing<number>().and(Nothing<number>())).toEqual(Nothing());
+    describe("mapWith", () => {
+      test("it returns a Nothing when mapWith Nothing", () => {
+        expect(Nothing<number>().mapWith(Nothing<number>(), () => 1)).toEqual(Nothing());
       });
 
-      test("it returns Nothing and-ed to a Just", () => {
-        expect(Nothing<number>().and(Just(1))).toEqual(Nothing());
+      test("it returns a Nothing when mapWith Just", () => {
+        expect(Nothing<number>().mapWith(Just(1), () => 1)).toEqual(Nothing());
+      });
+    });
+
+    describe("pair", () => {
+      test("it returns Nothing paired to a Nothing", () => {
+        expect(Nothing<number>().pair(Nothing<number>())).toEqual(Nothing());
+      });
+
+      test("it returns Nothing paired to a Just", () => {
+        expect(Nothing<number>().pair(Just(1))).toEqual(Nothing());
       });
     });
 
@@ -56,13 +66,23 @@ describe("Maybe", () => {
       });
     });
 
-    describe("and", () => {
-      test("it returns Nothing and-ed to a Nothing", () => {
-        expect(Just(1).and(Nothing<number>())).toEqual(Nothing());
+    describe("mapWith", () => {
+      test("it returns a Nothing when mapWith Nothing", () => {
+        expect(Just(1).mapWith(Nothing<number>(), (a, b) => a + b)).toEqual(Nothing());
       });
 
-      test("it returns a tuple and-ed to a Just", () => {
-        expect(Just(1).and(Just(2))).toEqual(Just([1,2]));
+      test("it returns a Nothing when mapWith Just", () => {
+        expect(Just(1).mapWith(Just(1), (a, b) => a + b)).toEqual(Just(2));
+      });
+    });
+
+    describe("pair", () => {
+      test("it returns Nothing paired to a Nothing", () => {
+        expect(Just(1).pair(Nothing<number>())).toEqual(Nothing());
+      });
+
+      test("it returns a tuple paired to a Just", () => {
+        expect(Just(1).pair(Just(2))).toEqual(Just([1,2]));
       });
     });
 

--- a/src/list.ts
+++ b/src/list.ts
@@ -7,7 +7,7 @@ class List<A>
     Cons: [A, List<A>];
   }>
   implements Functor<A> {
-  static empty() {
+  static empty(): List<unknown> {
     return Nil();
   }
 

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -21,6 +21,10 @@ class Maybe<T> extends SumType<{ Nothing: []; Just: [T] }> implements Monad<T> {
     });
   }
 
+  public and<U>(other: Maybe<U>): Maybe<[T, U]> {
+    return this.flatMap(mine => other.map(other => [mine, other]));
+  }
+
   public flatMap<U>(f: (t: T) => Maybe<U>): Maybe<U> {
     return this.caseOf({
       Nothing: () => Nothing(),

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -21,8 +21,12 @@ class Maybe<T> extends SumType<{ Nothing: []; Just: [T] }> implements Monad<T> {
     });
   }
 
-  public and<U>(other: Maybe<U>): Maybe<[T, U]> {
-    return this.flatMap(mine => other.map(other => [mine, other]));
+  public mapWith<U, R>(other: Maybe<U>, f: (mine: T, other: U) => R): Maybe<R> {
+    return this.flatMap(mine => other.map(other => f(mine, other)));
+  }
+
+  public pair<U>(other: Maybe<U>): Maybe<[T, U]> {
+    return this.mapWith(other, (mine, other) => [mine, other]);
   }
 
   public flatMap<U>(f: (t: T) => Maybe<U>): Maybe<U> {

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -21,12 +21,12 @@ class Maybe<T> extends SumType<{ Nothing: []; Just: [T] }> implements Monad<T> {
     });
   }
 
-  public mapWith<U, R>(other: Maybe<U>, f: (mine: T, other: U) => R): Maybe<R> {
+  public map2<U, R>(other: Maybe<U>, f: (mine: T, other: U) => R): Maybe<R> {
     return this.flatMap(mine => other.map(other => f(mine, other)));
   }
 
   public pair<U>(other: Maybe<U>): Maybe<[T, U]> {
-    return this.mapWith(other, (mine, other) => [mine, other]);
+    return this.map2(other, (mine, other) => [mine, other]);
   }
 
   public flatMap<U>(f: (t: T) => Maybe<U>): Maybe<U> {


### PR DESCRIPTION
👋 @hojberg 😄 !! Just putting this here; I've found it helpful in some of my use of `seidr` so I figured I'd just see if it's worth adding proper.

Adding the ability to combine two `Maybe`s into a single `Maybe` with the contents of the two placed into a tuple. This is inspired by rust's [`Option::zip`](https://doc.rust-lang.org/std/option/enum.Option.html#method.zip) (which maybe should be the name here too?).